### PR TITLE
Update default chainspec values

### DIFF
--- a/execution_engine/src/shared/host_function_costs.rs
+++ b/execution_engine/src/shared/host_function_costs.rs
@@ -19,8 +19,8 @@ const NOT_USED: Cost = 0;
 /// An arbitrary default fixed cost for host functions that were not researched yet.
 const DEFAULT_FIXED_COST: Cost = 200;
 
-const DEFAULT_ADD_ASSOCIATED_KEY_COST: u32 = 9_000;
 const DEFAULT_ADD_COST: u32 = 5_800;
+const DEFAULT_ADD_ASSOCIATED_KEY_COST: u32 = 9_000;
 
 const DEFAULT_CALL_CONTRACT_COST: u32 = 4_500;
 const DEFAULT_CALL_CONTRACT_ARGS_SIZE_WEIGHT: u32 = 420;
@@ -60,7 +60,7 @@ const DEFAULT_REMOVE_KEY_COST: u32 = 61_000;
 const DEFAULT_REMOVE_KEY_NAME_SIZE_WEIGHT: u32 = 3_200;
 
 const DEFAULT_RET_COST: u32 = 23_000;
-const DEFAULT_RET_VALUE_SIZE_WEIGHT: u32 = 420;
+const DEFAULT_RET_VALUE_SIZE_WEIGHT: u32 = 420_000;
 
 const DEFAULT_REVERT_COST: u32 = 500;
 const DEFAULT_SET_ACTION_THRESHOLD_COST: u32 = 74_000;
@@ -86,6 +86,7 @@ pub(crate) const DEFAULT_HOST_FUNCTION_NEW_DICTIONARY: HostFunction<[Cost; 1]> =
 /// The total gas cost is equal to `cost` + sum of each argument weight multiplied by the byte size
 /// of the data.
 #[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct HostFunction<T> {
     /// How much the user is charged for calling the host function.
     cost: Cost,
@@ -197,6 +198,7 @@ where
 
 /// Definition of a host function cost table.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct HostFunctionCosts {
     /// Cost of calling the `read_value` host function.
     pub read_value: HostFunction<[Cost; 3]>,

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -51,23 +51,23 @@ pub const DEFAULT_CONTROL_FLOW_ELSE_OPCODE: u32 = 440;
 /// Default cost of the `end` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_END_OPCODE: u32 = 440;
 /// Default cost of the `br` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_OPCODE: u32 = 440000;
+pub const DEFAULT_CONTROL_FLOW_BR_OPCODE: u32 = 440_000;
 /// Default cost of the `br_if` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_IF_OPCODE: u32 = 440000;
-/// Default fixed cost of the `br_table` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_TABLE_OPCODE: u32 = 440000;
-/// Default multiplier for the size of targets in `br_table` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER: u32 = 100;
+pub const DEFAULT_CONTROL_FLOW_BR_IF_OPCODE: u32 = 440_000;
 /// Default cost of the `return` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_RETURN_OPCODE: u32 = 440;
-/// Default cost of the `call` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_CALL_OPCODE: u32 = 440;
-/// Default cost of the `call_indirect` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE: u32 = 440;
-/// Default cost of the `drop` Wasm opcode.
-pub const DEFAULT_CONTROL_FLOW_DROP_OPCODE: u32 = 440;
 /// Default cost of the `select` Wasm opcode.
 pub const DEFAULT_CONTROL_FLOW_SELECT_OPCODE: u32 = 440;
+/// Default cost of the `call` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_CALL_OPCODE: u32 = 140_000;
+/// Default cost of the `call_indirect` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_CALL_INDIRECT_OPCODE: u32 = 140_000;
+/// Default cost of the `drop` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_DROP_OPCODE: u32 = 440;
+/// Default fixed cost of the `br_table` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_BR_TABLE_OPCODE: u32 = 440_000;
+/// Default multiplier for the size of targets in `br_table` Wasm opcode.
+pub const DEFAULT_CONTROL_FLOW_BR_TABLE_MULTIPLIER: u32 = 100;
 
 /// Definition of a cost table for a Wasm `br_table` opcode.
 ///
@@ -78,6 +78,7 @@ pub const DEFAULT_CONTROL_FLOW_SELECT_OPCODE: u32 = 440;
 /// ```
 // This is done to encourage users to avoid writing code with very long `br_table`s.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct BrTableCost {
     /// Fixed cost charge for `br_table` opcode.
     pub cost: u32,
@@ -144,6 +145,7 @@ impl FromBytes for BrTableCost {
 
 /// Definition of a cost table for a Wasm control flow opcodes.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct ControlFlowCosts {
     /// Cost for `block` opcode.
     pub block: u32,
@@ -324,6 +326,7 @@ impl Distribution<ControlFlowCosts> for Standard {
 ///
 /// This is taken (partially) from parity-ethereum.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct OpcodeCosts {
     /// Bit operations multiplier.
     pub bit: u32,

--- a/execution_engine/src/shared/storage_costs.rs
+++ b/execution_engine/src/shared/storage_costs.rs
@@ -9,10 +9,11 @@ use casper_types::{
 };
 
 /// Default gas cost per byte stored.
-pub const DEFAULT_GAS_PER_BYTE_COST: u32 = 625_000;
+pub const DEFAULT_GAS_PER_BYTE_COST: u32 = 630_000;
 
 /// Represents a cost table for storage costs.
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct StorageCosts {
     /// Gas charged per byte stored in the global state.
     gas_per_byte: u32,

--- a/execution_engine/src/shared/system_config.rs
+++ b/execution_engine/src/shared/system_config.rs
@@ -23,6 +23,7 @@ pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 100_000_000;
 /// This structure contains the costs of all the system contract's entry points and, additionally,
 /// it defines a wasmless transfer cost.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct SystemConfig {
     /// Wasmless transfer cost expressed in gas.
     wasmless_transfer_cost: u32,

--- a/execution_engine/src/shared/system_config/auction_costs.rs
+++ b/execution_engine/src/shared/system_config/auction_costs.rs
@@ -9,13 +9,13 @@ pub const DEFAULT_GET_ERA_VALIDATORS_COST: u32 = 10_000;
 /// Default cost of the `read_seigniorage_recipients` auction entry point.
 pub const DEFAULT_READ_SEIGNIORAGE_RECIPIENTS_COST: u32 = 10_000;
 /// Default cost of the `add_bid` auction entry point.
-pub const DEFAULT_ADD_BID_COST: u32 = 10_000;
+pub const DEFAULT_ADD_BID_COST: u32 = 2_500_000_000;
 /// Default cost of the `withdraw_bid` auction entry point.
-pub const DEFAULT_WITHDRAW_BID_COST: u32 = 10_000;
+pub const DEFAULT_WITHDRAW_BID_COST: u32 = 2_500_000_000;
 /// Default cost of the `delegate` auction entry point.
-pub const DEFAULT_DELEGATE_COST: u32 = 10_000;
+pub const DEFAULT_DELEGATE_COST: u32 = 2_500_000_000;
 /// Default cost of the `undelegate` auction entry point.
-pub const DEFAULT_UNDELEGATE_COST: u32 = 10_000;
+pub const DEFAULT_UNDELEGATE_COST: u32 = 2_500_000_000;
 /// Default cost of the `run_auction` auction entry point.
 pub const DEFAULT_RUN_AUCTION_COST: u32 = 10_000;
 /// Default cost of the `slash` auction entry point.
@@ -33,6 +33,7 @@ pub const DEFAULT_ACTIVATE_BID_COST: u32 = 10_000;
 
 /// Description of the costs of calling auction entrypoints.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct AuctionCosts {
     /// Cost of calling the `get_era_validators` entry point.
     pub get_era_validators: u32,

--- a/execution_engine/src/shared/system_config/handle_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/handle_payment_costs.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 10_000;
 
 /// Description of the costs of calling `handle_payment` entrypoints.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct HandlePaymentCosts {
     /// Cost of calling the `get_payment_purse` entry point.
     pub get_payment_purse: u32,

--- a/execution_engine/src/shared/system_config/mint_costs.rs
+++ b/execution_engine/src/shared/system_config/mint_costs.rs
@@ -19,6 +19,7 @@ pub const DEFAULT_READ_BASE_ROUND_REWARD_COST: u32 = 10_000;
 
 /// Description of the costs of calling mint entry points.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct MintCosts {
     /// Cost of calling the `mint` entry point.
     pub mint: u32,

--- a/execution_engine/src/shared/system_config/standard_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/standard_payment_costs.rs
@@ -9,6 +9,7 @@ const DEFAULT_PAY_COST: u32 = 10_000;
 
 /// Description of the costs of calling standard payment entry points.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct StandardPaymentCosts {
     /// Cost of calling the `pay` entry point.
     pub pay: u32,

--- a/execution_engine/src/shared/wasm_config.rs
+++ b/execution_engine/src/shared/wasm_config.rs
@@ -12,13 +12,14 @@ use super::{
 /// Default maximum number of pages of the Wasm memory.
 pub const DEFAULT_WASM_MAX_MEMORY: u32 = 64;
 /// Default maximum stack height.
-pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 188;
+pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 200;
 
 /// Configuration of the Wasm execution environment.
 ///
 /// This structure contains various Wasm execution configuration options, such as memory limits,
 /// stack limits and costs.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
+#[serde(deny_unknown_fields)]
 pub struct WasmConfig {
     /// Maximum amount of heap memory (represented in 64kB pages) each contract can use.
     pub max_memory: u32,

--- a/execution_engine_testing/test_support/Cargo.toml
+++ b/execution_engine_testing/test_support/Cargo.toml
@@ -27,6 +27,7 @@ toml = "0.5.6"
 tempfile = "3"
 
 [dev-dependencies]
+casper-types = { version = "1.6.0", path = "../../types", features = ["std"] }
 version-sync = "0.9.3"
 
 [features]

--- a/execution_engine_testing/test_support/src/auction.rs
+++ b/execution_engine_testing/test_support/src/auction.rs
@@ -74,7 +74,7 @@ pub fn run_blocks_with_transfers_and_step(
         &validator_keys,
         delegator_keys
             .iter()
-            .map(|pk| pk.to_account_hash())
+            .map(|public_key| public_key.to_account_hash())
             .collect::<Vec<_>>(),
         U512::from(TEST_DELEGATOR_INITIAL_ACCOUNT_BALANCE),
     );
@@ -342,7 +342,7 @@ pub fn create_delegate_request(
     let deploy = DeployItemBuilder::new()
         .with_address(delegator_account_hash)
         .with_stored_session_hash(contract_hash, entry_point, args)
-        .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => U512::from(100_000_000), })
+        .with_empty_payment_bytes(runtime_args! { ARG_AMOUNT => U512::from(2_500_000_000_u64) })
         .with_authorization_keys(&[delegator_account_hash])
         .with_deploy_hash(deploy_hash)
         .build();

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -142,8 +142,6 @@ nop = 200
 current_memory = 290
 # Grow memory cost, per page (64kb).
 grow_memory = 240_000
-# Regular opcode cost.
-regular = 210
 
 # Control flow operations multiplier.
 [wasm.opcode_costs.control_flow]

--- a/resources/production/chainspec.toml
+++ b/resources/production/chainspec.toml
@@ -145,8 +145,6 @@ nop = 200
 current_memory = 290
 # Grow memory cost, per page (64kb).
 grow_memory = 240_000
-# Regular opcode cost.
-regular = 210
 
 # Control flow operations multiplier.
 [wasm.opcode_costs.control_flow]


### PR DESCRIPTION
This PR:
* updates several outdated default consts around EE configuration values
* adds a test to match production chainspec values against these const defaults
* fixes two tests which failed as a result of these updates
* adds `#[serde(deny_unknown_fields)]` to all the config structs so that stray entries in a chainspec.toml will be detected
* removes the now-unused `[wasm.opcode_costs.regular]` from the two chainspec.toml files